### PR TITLE
Fix passing opts to command line arguments

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ const weasyprint = async (input, { command = 'weasyprint', ...opts } = {}) => {
     const isUrl = /^(https?|file):\/\//.test(input);
     const args = [command];
 
-    Object.entries(opts).forEach((key, value) => {
+    Object.entries(opts).forEach(([key, value]) => {
         args.push(key.length === 1 ? '-' + key : '--' + dasher(key));
         // only add value if it is not a boolean
         if (value !== false && value !== true) {

--- a/index.js
+++ b/index.js
@@ -17,8 +17,12 @@ const weasyprint = async (input, { command = 'weasyprint', ...opts } = {}) => {
     const isUrl = /^(https?|file):\/\//.test(input);
     const args = [command];
 
-    Object.keys(opts).forEach((key) => {
+    Object.entries(opts).forEach((key, value) => {
         args.push(key.length === 1 ? '-' + key : '--' + dasher(key));
+        // only add value if it is not a boolean
+        if (value !== false && value !== true) {
+            args.push(value);
+        }
     });
 
     args.push(isUrl ? quote(input) : '-'); // stdin if HTML given directly

--- a/index.js
+++ b/index.js
@@ -15,11 +15,10 @@ const quote = val => (typeof val === 'string' && process.platform !== 'win32')
 const weasyprint = async (input, { command = 'weasyprint', ...opts } = {}) => {
     let child;
     const isUrl = /^(https?|file):\/\//.test(input);
-    const keys = Object.keys(opts);
     const args = [command];
 
-    keys.forEach((key, index, arry) => {
-        arry[index] = key.length === 1 ? '-' + key : '--' + dasher(key);
+    Object.keys(opts).forEach((key) => {
+        args.push(key.length === 1 ? '-' + key : '--' + dasher(key));
     });
 
     args.push(isUrl ? quote(input) : '-'); // stdin if HTML given directly


### PR DESCRIPTION
Hello,

I had to be able to pass `-f pdf` command line argument, because my output was made to stdout.

Although, it seems there was a bug with opts parsing, because they were never used before.

This PR fix by adding key and values to the command line arguments.

Note that boolean values are ignored, so the user can add arguments without values if needed.